### PR TITLE
Fix parsing of hyphens in ranges

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -169,7 +169,11 @@ func parseRepetition(defaultMin, defaultMax int, repetition ...int) (min int, ma
 func parseMatcher(matcher string) (alphabet string, ranges [][]rune) {
 	runes := []rune(matcher)
 
-	for i := 0; i < len(runes); i++ {
+	i := 0
+	for {
+		if i >= len(runes) {
+			break
+		}
 
 		if i+2 < len(runes) && runes[i+1] == '-' && runes[i] != '\\' {
 			start := runes[i]
@@ -179,14 +183,17 @@ func parseMatcher(matcher string) (alphabet string, ranges [][]rune) {
 			} else {
 				ranges = append(ranges, []rune{end, start})
 			}
-		} else if i+1 < len(runes) && runes[i] == '\\' {
-			alphabet += string(runes[i+1])
-		} else if runes[i] == '-' {
+			i += 3 // we just consumed 3 bytes: range start, hyphen, and range end
 			continue
+		}
+
+		if i+1 < len(runes) && runes[i] == '\\' {
+			alphabet += string(runes[i+1])
 		} else {
 			alphabet += string(runes[i])
 		}
 
+		i++
 	}
 
 	return alphabet, ranges

--- a/parser.go
+++ b/parser.go
@@ -181,6 +181,8 @@ func parseMatcher(matcher string) (alphabet string, ranges [][]rune) {
 			}
 		} else if i+1 < len(runes) && runes[i] == '\\' {
 			alphabet += string(runes[i+1])
+		} else if runes[i] == '-' {
+			continue
 		} else {
 			alphabet += string(runes[i])
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -114,7 +114,7 @@ func TestChars(t *testing.T) {
 	t.Run("unescaped hyphen", func(t *testing.T) {
 		node, ps := runParser("19-", Chars("0-9"))
 		require.Equal(t, "19", node.Token)
-		require.Equal(t, 2, ps.Pos)
+		require.Equal(t, "-", ps.Get()) // hyphen shouldn't have been parsed
 		require.False(t, ps.Errored())
 	})
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -111,6 +111,13 @@ func TestChars(t *testing.T) {
 		require.False(t, ps.Errored())
 	})
 
+	t.Run("unescaped hyphen", func(t *testing.T) {
+		node, ps := runParser("19-", Chars("0-9"))
+		require.Equal(t, "19", node.Token)
+		require.Equal(t, 2, ps.Pos)
+		require.False(t, ps.Errored())
+	})
+
 	t.Run("no match", func(t *testing.T) {
 		_, ps := runParser("ffffff", Chars("0-9"))
 		require.Equal(t, "offset 0: expected 0-9", ps.Error.Error())


### PR DESCRIPTION
Noticed that any call to `Chars()` with a range (e.g. `0-9`) will match also match the hyphen in the range. Thus, during alphabet parsing, `parseMatcher` actually sees the hyphen twice: once as part of the range, once as a standalone.

I thought the cleanest solution was to manually increment the iterator in the `for` loop during alphabet parsing, giving the conditional which parses a range the opportunity to increment the iterator past the range's bytes. This prevents revisiting the hyphen twice.

All tests pass, including `calc_test.go`, which contains a standalone hyphen in a call to `Chars`.