### PR TITLE
Remove old branch prediction code

### DIFF
--- a/combinator.go
+++ b/combinator.go
@@ -45,13 +45,13 @@ func Any(parsers ...Parserish) Parser {
 		}
 		startpos := ps.Pos
 
-		longestError := ps.Error
 		if ps.Cut <= startpos {
 			ps.Recover()
 		} else {
 			return
 		}
 
+		var longestError Error
 		for _, parser := range parserfied {
 			parser(ps, node)
 			if ps.Errored() {

--- a/combinator.go
+++ b/combinator.go
@@ -35,7 +35,6 @@ func NoAutoWS(parser Parserish) Parser {
 // Any matches the first successful parser and returns its result
 func Any(parsers ...Parserish) Parser {
 	parserfied := ParsifyAll(parsers...)
-	// Records which parser was successful for each byte, and will use it first next time.
 
 	return NewParser("Any()", func(ps *State, node *Result) {
 		ps.WS(ps)
@@ -44,12 +43,6 @@ func Any(parsers ...Parserish) Parser {
 			return
 		}
 		startpos := ps.Pos
-
-		if ps.Cut <= startpos {
-			ps.Recover()
-		} else {
-			return
-		}
 
 		var longestError Error
 		for _, parser := range parserfied {

--- a/combinator_test.go
+++ b/combinator_test.go
@@ -87,6 +87,17 @@ func TestAny(t *testing.T) {
 			require.Equal(t, "a", node.Child[1].Token)
 
 		})
+
+		// see https://github.com/vektah/goparsify/issues/3
+		t.Run("doesn't succeed early after caller error", func(t *testing.T) {
+			str := "str"
+			str1 := Seq("str", "1")
+			str2 := Any("str2")
+			p := Any(str1, str2, str)
+			_, ps := runParser("str", p)
+			require.False(t, ps.Errored())
+			require.Equal(t, "", ps.Get())
+		})
 	})
 }
 


### PR DESCRIPTION
fixes #3 

The root of the problem is saving the existing `ps.Error` https://github.com/vektah/goparsify/blob/3e20a3b9244aa003fcaf26a625ef48246aef55f7/combinator.go#L48 which was originally added as part of the old branch prediction code and no longer makes sense. The error from an `Any` parser should be the longest error from its child parsers, and it should not worry about its caller's last error, as it is doing now.

Here's what goes wrong in the [example](https://github.com/vektah/goparsify/issues/3#issue-336966497) from @austin-distilled: After `str1` fails with the error `{pos:3,expected:"1"}`, `parser` recovers and tries `str2`. However, the recovered error retains its `pos` value, and because `str2` starts by saving the recovered error as `longestError`, that error preempts the actual error from the (implicit) `Exact("str2")` parser when `str2` returns. The recovered error then makes `parser` incorrectly think that `str2` succeeded before `parser` even tries `str`.

I've returned `Any` to its old behavior by starting with an empty `longestError`. Since the `ps.Cut` condition was also an obsolete piece of the branch prediction logic, I removed it too.