### PR TITLE
Fix nested Any() not correctly tracking longestError. Fixes #3

### DIFF
--- a/combinator.go
+++ b/combinator.go
@@ -55,7 +55,7 @@ func Any(parsers ...Parserish) Parser {
 		for _, parser := range parserfied {
 			parser(ps, node)
 			if ps.Errored() {
-				if ps.Error.pos >= longestError.pos {
+				if ps.Error.pos >= longestError.pos || longestError.expected == "" {
 					longestError = ps.Error
 				}
 				if ps.Cut > startpos {

--- a/combinator_test.go
+++ b/combinator_test.go
@@ -1,10 +1,9 @@
 package goparsify
 
 import (
-	"testing"
-
 	"fmt"
 	"os"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )
@@ -86,6 +85,23 @@ func TestAny(t *testing.T) {
 			require.Equal(t, "ab", node.Child[0].Token)
 			require.Equal(t, "a", node.Child[1].Token)
 
+		})
+	})
+
+	t.Run("Nested", func(t *testing.T) {
+		anyTrueFalse := Any("true", "false")
+		seq := Seq(Chars("a-z", 1), ":")
+
+		t.Run("Any(Seq,Any)", func(t *testing.T) {
+			node, ps := runParser("bob", Any(seq, anyTrueFalse))
+			require.True(t, ps.Errored(), "error:%#v result:%#v", ps.Error, node)
+			require.EqualError(t, &ps.Error, "offset 3: expected :")
+		})
+
+		t.Run("Any(Any,Seq)", func(t *testing.T) {
+			node, ps := runParser("bob", Any(anyTrueFalse, seq))
+			require.True(t, ps.Errored(), "error:%#v result:%#v", ps.Error, node)
+			require.EqualError(t, &ps.Error, "offset 3: expected :")
 		})
 	})
 }


### PR DESCRIPTION
We ran into this issue with nested Any() as well, digging into the debug traces, you can see that the inner any failed the individual parsers but didn't return any error back up the chain.
```
=== RUN   TestAny/Nested/Any(Seq,Any)
combinator_test.go:97 | bob             | ps {
combinator_test.go:94 | bob             |   seq {
combinator_test.go:94 |                 |     [a-z] found "bob"
combinator_test.go:94 |                 |     : did not find :
combinator_test.go:94 | bob             |   } did not find :
combinator_test.go:93 | bob             |   anyTrueFalse {
combinator_test.go:93 | bob             |     true did not find true
combinator_test.go:93 | bob             |     false did not find false
combinator_test.go:93 | bob             |   } found "[bob,]"
combinator_test.go:97 | bob             | } found "[bob,]"
```

What happens is in the outer Any() it runs a parser which sets an error, it then calls recover and calls the next parser. If that parser is an Any() then it saves error in longestError, but because recover was called, pos is set, but expected is empty. Subsequently the inner Any() will check the error pos against longest, but if all the inner Any()'s errors are before the outer one, it ends up returning out of the inner any() without having updated longestError. When it then returns back up the chain, error.expected is still not set.

This fix checks expected as well as pos when checking if it should update longestError. 